### PR TITLE
Introducing changes required to run scripts in IDC Inflow image building

### DIFF
--- a/base/2_kernel_setup.sh
+++ b/base/2_kernel_setup.sh
@@ -3,8 +3,8 @@
 export DEBIAN_FRONTEND=noninteractive
 export DEBIAN_FRONTEND=noninteractive
 export NEEDRESTART_MODE=a
-KERNEL_NAME="linux-image-5.15.0-57-generic"
-KERNEL_VERSION="5.15.0-57"
+KERNEL_NAME="linux-image-5.15.0-73-generic"
+KERNEL_VERSION="5.15.0-73"
 
 alias sudo="sudo -E"
 colored_output() {
@@ -50,6 +50,10 @@ else
     colored_output "ERROR: Failed to set kernel ${KERNEL_VERSION}-generic as the default kernel." red
     exit 1
 fi
-colored_output "Rebooting in 10 seconds to apply the new kernel..." blue
-sleep 10
-sudo reboot
+
+if [ -z "$OMMIT_REBOOT" ]
+then
+    colored_output "Rebooting in 10 seconds to apply the new kernel..." blue
+    sleep 10
+    sudo reboot
+fi

--- a/base/3_gpu_drivers_setup.sh
+++ b/base/3_gpu_drivers_setup.sh
@@ -5,7 +5,7 @@ export NEEDRESTART_MODE=a
 alias sudo="sudo -E"
 set -e
 
-KERNEL_VERSION="5.15.0-57"
+KERNEL_VERSION="5.15.0-73"
 REPO_URL="https://repositories.intel.com/graphics"
 REPO_KEY_URL="${REPO_URL}/intel-graphics.key"
 REPO_LIST_FILE="/etc/apt/sources.list.d/intel.gpu.jammy.list"
@@ -75,6 +75,9 @@ sudo apt-get install -y \
   libdrm-dev
 
 # Reboot
-colored_output "Rebooting the system in 10 seconds..." blue
-sleep 10
-sudo reboot
+if [ -z "$OMMIT_REBOOT" ]
+then
+    colored_output "Rebooting the system in 10 seconds..." blue
+    sleep 10
+    sudo reboot
+fi

--- a/base/4_hold-packages.sh
+++ b/base/4_hold-packages.sh
@@ -12,7 +12,7 @@ colored_output() {
     esac
 }
 
-KERNEL_VERSION="5.15.0-57"
+KERNEL_VERSION="5.15.0-73"
 KERNEL_PACKAGE="linux-image-${KERNEL_VERSION}-generic"
 KERNEL_HEADER_PACKAGE="linux-headers-${KERNEL_VERSION}-generic"
 INTEL_PACKAGES=("intel-i915-dkms" "intel-fw-gpu" "intel-platform-vsec-dkms" "intel-platform-cse-dkms")

--- a/base/5_env_dev_utils_setup.sh
+++ b/base/5_env_dev_utils_setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 export DEBIAN_FRONTEND=noninteractive
 export NEEDRESTART_MODE=a
 alias sudo="sudo -E"
@@ -59,7 +59,7 @@ EOF
 
 # enable and start the service
 sudo systemctl enable set-cpufreq-governor.service
-sudo systemctl start set-cpufreq-governor.service
+[ -n "$OMMIT_SERVICE_START" ] && sudo systemctl start set-cpufreq-governor.service
 
 # install required packages
 colored_output "Installing required packages..." blue
@@ -105,6 +105,10 @@ echo "ulimit -u 65535" | sudo tee -a /etc/security/limits.conf
 # inform user
 colored_output "Cleanup..." blue
 sudo apt -y autoremove
-colored_output "Setup completed. Rebooting in 10 seconds..." blue
-sleep 10
-sudo reboot
+
+if [ -z "$OMMIT_REBOOT" ]
+then
+    colored_output "Setup completed. Rebooting in 10 seconds..." blue
+    sleep 10
+    sudo reboot
+fi

--- a/base/9_cleanup.sh
+++ b/base/9_cleanup.sh
@@ -4,8 +4,8 @@ set -e
 export DEBIAN_FRONTEND=noninteractive
 export DEBIAN_FRONTEND=noninteractive
 export NEEDRESTART_MODE=a
-KERNEL_NAME="linux-image-5.15.0-57-generic"
-KERNEL_VERSION="5.15.0-57"
+KERNEL_NAME="linux-image-5.15.0-73-generic"
+KERNEL_VERSION="5.15.0-73"
 
 alias sudo="sudo -E"
 colored_output() {
@@ -26,6 +26,9 @@ sudo apt update &&\
   sudo apt autoremove
 
 # Reboot
-colored_output "Rebooting the system in 10 seconds..." blue
-sleep 10
-sudo reboot
+if [ -z "$OMMIT_REBOOT" ]
+then
+    colored_output "Rebooting the system in 10 seconds..." blue
+    sleep 10
+    sudo reboot
+fi

--- a/utils/update_kernel.py
+++ b/utils/update_kernel.py
@@ -14,7 +14,7 @@ if args.arc:
     DEFAULT_KERNEL_NAME = "linux-image-5.17.0-35-generic"
 else:
     KERNEL_URL = "https://dgpu-docs.intel.com/_sources/installation-guides/ubuntu/ubuntu-jammy-max.md.txt"
-    DEFAULT_KERNEL_NAME = "linux-image-5.15.0-57-generic"
+    DEFAULT_KERNEL_NAME = "linux-image-5.15.0-73-generic"
 
 def update_kernel_version(KERNEL_URL, DEFAULT_KERNEL_NAME):
     try:


### PR DESCRIPTION
Following changes were made to mage scripts applicable for unattended installation.

Adding environment variables:
- OMMIT_REBOOT - when set causes scripts to omit reboot command
- OMMIT_SERVICE_START - when set prevents scripts from starting services

Bumping up target kernel version from 5.15.0-57 to 5.15.0-73 - older version was no longer valid.