### PR TITLE
Adding changes required for this code to be used in IDC Inflow

### DIFF
--- a/base/2_kernel_setup.sh
+++ b/base/2_kernel_setup.sh
@@ -50,6 +50,10 @@ else
     colored_output "ERROR: Failed to set kernel ${KERNEL_VERSION}-generic as the default kernel." red
     exit 1
 fi
-colored_output "Rebooting in 10 seconds to apply the new kernel..." blue
-sleep 10
-sudo reboot
+
+if [ -z "$OMMIT_REBOOT" ]
+then
+    colored_output "Rebooting in 10 seconds to apply the new kernel..." blue
+    sleep 10
+    sudo reboot
+fi

--- a/base/3_gpu_drivers_setup.sh
+++ b/base/3_gpu_drivers_setup.sh
@@ -75,6 +75,9 @@ sudo apt-get install -y \
   libdrm-dev
 
 # Reboot
-colored_output "Rebooting the system in 10 seconds..." blue
-sleep 10
-sudo reboot
+if [ -z "$OMMIT_REBOOT" ]
+then
+    colored_output "Rebooting the system in 10 seconds..." blue
+    sleep 10
+    sudo reboot
+fi

--- a/base/5_env_dev_utils_setup.sh
+++ b/base/5_env_dev_utils_setup.sh
@@ -59,7 +59,7 @@ EOF
 
 # enable and start the service
 sudo systemctl enable set-cpufreq-governor.service
-sudo systemctl start set-cpufreq-governor.service
+[ -z "$OMMIT_SERVICE_START" ] && sudo systemctl start set-cpufreq-governor.service
 
 # install required packages
 colored_output "Installing required packages..." blue
@@ -108,6 +108,10 @@ echo "ulimit -u 65535" | sudo tee -a /etc/security/limits.conf
 # inform user
 colored_output "Cleanup..." blue
 sudo apt -y autoremove
-colored_output "Setup completed. Rebooting in 10 seconds..." blue
-sleep 10
-sudo reboot
+
+if [ -z "$OMMIT_REBOOT" ]
+then
+    colored_output "Setup completed. Rebooting in 10 seconds..." blue
+    sleep 10
+    sudo reboot
+fi

--- a/base/9_cleanup.sh
+++ b/base/9_cleanup.sh
@@ -24,6 +24,9 @@ sudo apt update &&\
   sudo apt autoremove
 
 # Reboot
-colored_output "Rebooting the system in 10 seconds..." blue
-sleep 10
-sudo reboot
+if [ -z "$OMMIT_REBOOT" ]
+then
+    colored_output "Rebooting the system in 10 seconds..." blue
+    sleep 10
+    sudo reboot
+fi


### PR DESCRIPTION
In IDC Inflow images are provisioned using Ansible. 
Since Ansible is not good with reboots performed within the script and starting services doesn't make sense when building image a few environment variables are introduced to block these actions.

OMMIT_SERVICE_START - when non-empty services are not started 
OMMIT_REBOOT - when non-empty reboots are not performed