### PR TITLE
Adding changes required for this code to be used in IDC Inflow

### DIFF
--- a/base/2_kernel_setup.sh
+++ b/base/2_kernel_setup.sh
@@ -46,6 +46,10 @@ else
     colored_output "ERROR: Failed to set kernel ${KERNEL_VERSION}-generic as the default kernel." red
     exit 1
 fi
-colored_output "Rebooting in 10 seconds to apply the new kernel..." blue
-sleep 10
-sudo reboot
+
+if [ -z "$OMMIT_REBOOT" ]
+then
+    colored_output "Rebooting in 10 seconds to apply the new kernel..." blue
+    sleep 10
+    sudo reboot
+fi

--- a/base/3_gpu_drivers_setup.sh
+++ b/base/3_gpu_drivers_setup.sh
@@ -71,6 +71,9 @@ sudo apt-get install -y \
   level-zero-dev
 
 # Reboot
-colored_output "Rebooting the system in 10 seconds..." blue
-sleep 10
-sudo reboot
+if [ -z "$OMMIT_REBOOT" ]
+then
+    colored_output "Rebooting the system in 10 seconds..." blue
+    sleep 10
+    sudo reboot
+fi

--- a/base/5_env_dev_utils_setup.sh
+++ b/base/5_env_dev_utils_setup.sh
@@ -49,7 +49,7 @@ EOF
 
 # enable and start the service
 sudo systemctl enable set-cpufreq-governor.service
-sudo systemctl start set-cpufreq-governor.service
+[ -z "$OMMIT_SERVICE_START" ] && sudo systemctl start set-cpufreq-governor.service
 
 # install required packages
 colored_output "Installing required packages..." blue
@@ -84,6 +84,10 @@ sudo rm -rf ./"$XPU_DEB_NAME"
 # inform user
 colored_output "Cleanup..." blue
 sudo apt -y autoremove
-colored_output "Setup completed. Rebooting in 10 seconds..." blue
-sleep 10
-sudo reboot
+
+if [ -z "$OMMIT_REBOOT" ]
+then
+    colored_output "Setup completed. Rebooting in 10 seconds..." blue
+    sleep 10
+    sudo reboot
+fi


### PR DESCRIPTION
In IDC Inflow images are provisioned using Ansible. 
Since Ansible is not good with reboots performed within the script and starting services doesn't make sense when building image a few environment variables are introduced to block these actions.

OMMIT_SERVICE_START - when non-empty services are not started 
OMMIT_REBOOT - when non-empty reboots are not performed